### PR TITLE
Add extensions input

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ Issue Types reference: https://www.jetbrains.com/help/resharper/Reference__Code_
 Explicitly enable or disable solution-wide analysis. If not specified, solution-wide analysis will
 be enabled or disabled based on the existing settings.
 
+### extensions
+
+Comma-separated list of extensions to install.
+
+Example:
+
+```text
+StyleCop.StyleCop,ReSharperPlugin.CognitiveComplexity
+```
+
 ### workingDirectory
 
 The directory to run the command in. All paths (solution path, include/exclude patterns, etc) are

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   solutionWideAnalysis:
     required: false
     description: Explicitly enable or disable solution-wide analysis. If not specified, solution-wide analysis will be enabled or disabled based on the existing settings.
+  extensions:
+    required: false
+    description: Comma-separated list of extensions to install.
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,11 @@ async function run(): Promise<void> {
 
     command += ` --severity=${minimumReportSeverity}`
 
+    const extensions: string = core.getInput('extensions')
+    if (extensions) {
+      command += ` --extensions=${extensions.trim().replace(/(,\s?)|(;\s?)/g, ';')}`
+    }
+
     const workingDir: string = core.getInput('workingDirectory')
     if (workingDir) {
       core.debug(`Changing to working directory: ${workingDir}`)


### PR DESCRIPTION
This PR adds the `extensions` input, which allows this Action to pass the `--extensions` input to InspectCode, which allows the tool to install ReSharper extensions from the JetBrains Marketplace.
I was unable to test this PR as I do not have experience in using TypeScript.