### PR TITLE
Add the ability to write ignoreIssueType via newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,22 @@ Example:
 
 ### ignoreIssueType
 
-Comma-separated list of issue types to ignore.
+Comma-separated or line-separated list of issue types to ignore.
 
 Example:
 
 ```text
 UnusedField.Compiler,UnusedMember.Global
+```
+
+```yml
+- name: Inspect code
+  uses: muno92/resharper_inspectcode@v1
+  with:
+    solutionPath: ./YourSolution.sln
+    ignoreIssueType: |
+      UnusedField.Compiler
+      UnusedMember.Global
 ```
 
 Issue Types reference: https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ async function run(): Promise<void> {
 
     await exec.exec(command)
 
-    const ignoreIssueType = core.getInput('ignoreIssueType') ?? ''
+    const ignoreIssueType = (core.getInput('ignoreIssueType') ?? '').trim().replace(/[\r\n]+/g, ',')
 
     const report = new Report(outputPath, ignoreIssueType)
     report.output()


### PR DESCRIPTION
Previous
``` yml
- name: Inspect code
  uses: muno92/resharper_inspectcode@v1
  with:
    solutionPath: ./YourSolution.sln
    ignoreIssueType: UnusedField.Compiler,UnusedMember.Global
```

New
``` yml
- name: Inspect code
  uses: muno92/resharper_inspectcode@v1
  with:
    solutionPath: ./YourSolution.sln
    ignoreIssueType: |
      UnusedField.Compiler
      UnusedMember.Global
```