### PR TITLE
Add double quote to include parameter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ async function run(): Promise<void> {
 
     const include: string = core.getInput('include')
     if (include) {
-      command += ` --include=${include.trim().replace(/[\r\n]+/g, ';')}`
+      command += ` --include="${include.trim().replace(/[\r\n]+/g, ';')}"`
     }
 
     const exclude = core.getInput('exclude') ?? ''


### PR DESCRIPTION
I haven't retested this recently, but some months back I had trouble adding more than one pattern to include which seems to be due to there being no quotation used around the parameter value.