### PR TITLE
Update default ReSharper version to the latest version available

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Whether the action should fail if there are any issues.
   version:
     required: false
-    default: '2023.3.4'
+    default: '2024.1.0'
     description: Version of the Resharper CLI tool to install. Defaults to the latest XML version available.
   minimumReportSeverity:
     required: false


### PR DESCRIPTION
The latest version available is `2024.1.0`. Currently when running this action it tries to install version `2023.3.4` while a newer version is already installed.

It might be nice to enforce the installation of the selected version on the runner, when a specific version was submitted.

This will at least use the latest version again as default.