### PR TITLE
Don't use macos-13 for e2e test

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -15,8 +15,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
         dotnet-version: [ '3.1', '5.0', '6.0', '7.0', '8.0', '9.0' ]
-    # macos-latest is ARM Runner, so .NET Core 3.1 and .NET 5 cannot be used.
-    runs-on: ${{ (contains(fromJSON('["3.1", "5.0"]'), matrix.dotnet-version) && (matrix.operating-system == 'macos-latest' && 'macos-13') || (matrix.operating-system == 'ubuntu-latest' && 'ubuntu-22.04')) || matrix.operating-system }}
+    runs-on: ${{ (contains(fromJSON('["3.1", "5.0"]'), matrix.dotnet-version) && (matrix.operating-system == 'ubuntu-latest' && 'ubuntu-22.04')) || matrix.operating-system }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/