### PR TITLE
Drop support for .NET Core 3.1 and .NET 5

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet-version: [ '3.1', '5.0', '6.0', '7.0', '8.0', '9.0' ]
+        dotnet-version: [ '6.0', '7.0', '8.0', '9.0' ]
     runs-on: ${{ (contains(fromJSON('["3.1", "5.0"]'), matrix.dotnet-version) && (matrix.operating-system == 'ubuntu-latest' && 'ubuntu-22.04')) || matrix.operating-system }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Because, macos-latest runner can't use .NET Core 3.1 and .NET 5.