### PR TITLE
Drop .NET 6 support

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet-version: [ '6.0', '7.0', '8.0', '9.0' ]
-    runs-on: ${{ (contains(fromJSON('["3.1", "5.0"]'), matrix.dotnet-version) && (matrix.operating-system == 'ubuntu-latest' && 'ubuntu-22.04')) || matrix.operating-system }}
+        dotnet-version: [ '7.0', '8.0', '9.0' ]
+    runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ jobs:
         id: setup-dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x' # [6.0.x, 7.0.x, 8.0.x, 9.0.x]
+          dotnet-version: '9.0.x' # [7.0.x, 8.0.x, 9.0.x]
       - name: Restore
         run: dotnet restore
       - name: Inspect code


### PR DESCRIPTION
Because .NET 6 is deprecated on GitHub hosted-runner. https://github.blog/changelog/2024-08-19-notice-of-upcoming-
deprecations-and-breaking-changes-in-github-actions-runners/

Close: #489